### PR TITLE
Checking the $permalinks variable

### DIFF
--- a/permalink-settings.php
+++ b/permalink-settings.php
@@ -117,7 +117,7 @@ class AS_Admin_Permalink_Settings {
 		if ( isset( $_POST['permalink_structure'] ) && isset( $_POST['attachment_permalink'] ) ) {
 			$permalink = get_option( 'attachment_permalink' );
 
-			if (!empty($permalinks)) {
+			if (isset($permalinks) && !empty($permalinks)) {
 				$permalink = array();
 			}
 

--- a/permalink-settings.php
+++ b/permalink-settings.php
@@ -117,7 +117,7 @@ class AS_Admin_Permalink_Settings {
 		if ( isset( $_POST['permalink_structure'] ) && isset( $_POST['attachment_permalink'] ) ) {
 			$permalink = get_option( 'attachment_permalink' );
 
-			if ( ! $permalinks ) {
+			if (!empty($permalinks)) {
 				$permalink = array();
 			}
 


### PR DESCRIPTION
proper check if $permalinks isn't  #3 .

This should suffice for checking if the variable is actually set and that the content isn't empty.